### PR TITLE
Frantjc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG base_image=ubuntu:jammy
-ARG build_image=golang:latest
+ARG build_image=golang:1.16
 
 FROM ${base_image} AS base_image
 

--- a/Makefile
+++ b/Makefile
@@ -35,32 +35,22 @@ push-tasks: build-tasks
 save-tasks: build-tasks
 	$(DOCKER) save -o $(TASKS-TAR) $(TASKS-TAGS)
 
-.PHONY: datastore
-datastore:
-	$(DOCKER-COMPOSE) up -d datastore
-
-.PHONY: objectstore
-objectstore:
-	$(DOCKER-COMPOSE) up -d objectstore
-
-.PHONY: messagequeue
-messagequeue:
-	$(DOCKER-COMPOSE) up -d messagequeue
-
-.PHONY: services
-services: datastore objectstore messagequeue
+.PHONY: infra
+infra: save-tasks
+	$(DOCKER-COMPOSE) up -d datastore objectstore messagequeue
 
 .PHONY: build
-build: save-tasks
+build:
 	$(DOCKER-COMPOSE) build
 
 .PHONY: up
-up: build services
+up: build
 	$(DOCKER-COMPOSE) up migrate worker api
 
 .PHONY: restart
-restart:
-	$(DOCKER-COMPOSE) restart
+restart: build
+	$(DOCKER-COMPOSE) stop worker api
+	$(DOCKER-COMPOSE) up worker api
 
 .PHONY: scan
 scan: build
@@ -82,7 +72,7 @@ clean: down
 
 .PHONY: prune
 prune: clean
-	$(DOCKER) system prune -a
+	$(DOCKER) system prune --volumes -a
 
 .PHONY: test
 test: save-tasks

--- a/README.md
+++ b/README.md
@@ -22,8 +22,12 @@
 > `docker-compose` _requires credentials to be supplied through the shell via environment variables_ `AWS_ACCESS_KEY_ID` _and_ `AWS_SECRET_ACCESS_KEY` _or an environment file_ `.env` _in the root of the repository_
 
 ```sh
+# setup services, build tasks
+make infra
 # run geocloud
 make up
+# restart geocloud
+make restart
 ```
 
 ### Tasks
@@ -56,6 +60,6 @@ see [Postgres migration tutorial](https://github.com/golang-migrate/migrate/blob
 #### Migrate
 
 ```sh
-# run the migrations
+# run migrations
 geocloud migrate
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ networks:
 services:
   api:
     build: .
+    image: logsquaredn/geocloud:${GEOCLOUD_TAG:-latest}
     command: a --postgres-enabled --s3-enabled --s3-disable-ssl --s3-force-path-style --amqp-enabled --amqp-queue-name=geocloud
     volumes: [~/.aws/:/root/.aws/:ro]
     networks: [api]
@@ -24,6 +25,7 @@ services:
       GEOCLOUD_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY:-geocloud}
   migrate:
     build: .
+    image: logsquaredn/geocloud:${GEOCLOUD_TAG:-latest}
     command: m --postgres-enabled
     networks: [migrate]
     depends_on: [datastore]
@@ -63,5 +65,3 @@ services:
       <<: *environment
       GEOCLOUD_REGISTRY_USERNAME: ${GEOCLOUD_REGISTRY_USERNAME:-}
       GEOCLOUD_REGISTRY_PASSWORD: ${GEOCLOUD_REGISTRY_PASSWORD:-}
-
-volumes: {}


### PR DESCRIPTION
there are more fine-grained commands, but the high-level dev-cycle that this aims to provide is:

`make infra` (brings up objectstore, messagequeue and datastore; and builds tasks)
`make up` (builds/starts migrate/worker/api)
`make restart` (brings down worker/api, then builds/start them again)
`make down` (brings worker, api, objectstore, messagequeue and datastore down)

...

other maybe convenient ones:
`make save-tasks` (just rebuilds tasks)
`make prune` (raze absolutely everything)


